### PR TITLE
Fix setup, improve sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ several localities (e.g. California, Quebec).
 ## Example
 
 ```python
-    from healthcards import parser
-    jws_str = parser.decode_qr_to_jws("shc:/...")
-    jws = parser.JWS(jws_str)
-    jws.verified
-    jws.as_dict()
+record = "shc:/..."
+from healthcards import parser
+jws_str = parser.decode_qr_to_jws(record)
+jws = parser.JWS(jws_str)
+jws.verified
+jws.as_dict()
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="healthcards",
-    packages=find_packages(where="healthcards"),
+    packages=["healthcards"],
     version="0.1.0",
     description="Python parser for https://spec.smarthealth.cards",
     long_description=long_description,
@@ -20,4 +20,5 @@ setup(
     ],
     package_dir={"": "src"},
     python_requires=">=3.7",
+    install_requires=["jwcrypto"],
 )


### PR DESCRIPTION
While using this module, installation was failing to actually install the module. I fixed two errors, one where the module wasn't installed and one where a dependency wasn't installed.

Also I reformatted the sample usage so it's more copy-paste friendly. Users can just assign their record, then copy/paste to get a full example without running into indentation errors or having to pause to insert their record into the middle of the pasted code.